### PR TITLE
Group support

### DIFF
--- a/deployment_scripts/puppet/modules/plugin_ldap/manifests/controller.pp
+++ b/deployment_scripts/puppet/modules/plugin_ldap/manifests/controller.pp
@@ -29,6 +29,18 @@ class plugin_ldap::controller {
   $user_allow_update      = false
   $user_allow_delete      = false
 
+  $group_tree_dn          = $::fuel_settings['ldap']['group_tree_dn']
+  $group_filter           = $::fuel_settings['ldap']['group_filter']
+  $group_objectclass      = $::fuel_settings['ldap']['group_objectclass']
+  $group_id_attribute     = $::fuel_settings['ldap']['group_id_attribute']
+  $group_name_attribute   = $::fuel_settings['ldap']['group_name_attribute']
+  $group_member_attribute = $::fuel_settings['ldap']['group_member_attribute']
+  $group_desc_attribute   = $::fuel_settings['ldap']['group_desc_attribute']
+
+  $group_allow_create     = false
+  $group_allow_update     = false
+  $group_allow_delete     = false
+
   $domain                 = $::fuel_settings['ldap']['domain']
 
   file { '/etc/keystone/domains':
@@ -65,6 +77,16 @@ class plugin_ldap::controller {
     "${domain}/ldap/user_allow_create":      value => $user_allow_create;
     "${domain}/ldap/user_allow_update":      value => $user_allow_update;
     "${domain}/ldap/user_allow_delete":      value => $user_allow_delete;
+    "${domain}/ldap/group_tree_dn":          value => $group_tree_dn;
+    "${domain}/ldap/group_filter":           value => $group_filter;
+    "${domain}/ldap/group_objectclass":      value => $group_objectclass;
+    "${domain}/ldap/group_id_attribute":     value => $group_id_attribute;
+    "${domain}/ldap/group_name_attribute":   value => $group_name_attribute;
+    "${domain}/ldap/group_member_attribute": value => $group_member_attribute;
+    "${domain}/ldap/group_desc_attribute":   value => $group_desc_attribute;
+    "${domain}/ldap/group_allow_create":     value => $group_allow_create;
+    "${domain}/ldap/group_allow_update":     value => $group_allow_update;
+    "${domain}/ldap/group_allow_delete":     value => $group_allow_delete;
   } ~>
   service { 'httpd':
     name     => "$apache::params::service_name",

--- a/environment_config.yaml
+++ b/environment_config.yaml
@@ -86,3 +86,45 @@ attributes:
     description: 'LDAP attribute mapped to enabled/disabled.'
     weight: 66
     type: "text"
+  group_tree_dn:
+    value: 'ou=Groups,dc=example,dc=com'
+    label: 'Groups Tree DN'
+    description: 'Search base for groups.'
+    weight: 67
+    type: "text"
+  group_filter:
+    value: ''
+    label: 'Group Filter'
+    description: 'LDAP search filter for groups.'
+    weight: 68
+    type: "text"
+  group_objectclass:
+    value: 'groupOfNames'
+    label: 'Group Object Class'
+    description: 'LDAP objectclass for groups.'
+    weight: 69
+    type: "text"
+  group_id_attribute:
+    value: 'cn'
+    label: 'Group ID Attribute'
+    description: 'LDAP attribute mapped to group id.'
+    weight: 70
+    type: "text"
+  group_name_attribute:
+    value: 'ou'
+    label: 'Group Name Attribute'
+    description: 'LDAP attribute mapped to group name.'
+    weight: 71
+    type: "text"
+  group_member_attribute:
+    value: 'member'
+    label: 'Group Member Attribute'
+    description: 'LDAP attribute that maps user to group.'
+    weight: 72
+    type: "text"
+  group_desc_attribute:
+    value: 'description'
+    label: 'Group description Attribute'
+    description: 'LDAP attribute mapped to description.'
+    weight: 73
+    type: "text"


### PR DESCRIPTION
As Groups are another really useful entity if Keystone Identity, it is stored in ldap in current implementation but we have no means to specify it. Moreover customer will see error in horizon once he try to do any actions on groups.

Why groups are useful:
1) Imagine Ldap catalog with hundreds of users. Usually the are members of some groups. Then we add openstack. If we do not have ability to mange correctly get groups from ldap we will have to assign role in project for every single user(thats really awful ). And we go with groups we will need to assign roles only for groups thus users will get rights as members of a group.

2) Now imagen adding new user. Administrator will have to go to horizon and add user every new user to all projects instead of creating it and adding to required group in ldap once.
