### PR TITLE
Allow empty passwords for anonymous binding

### DIFF
--- a/environment_config.yaml
+++ b/environment_config.yaml
@@ -54,7 +54,7 @@ attributes:
     weight: 35
     type: "password"
     regex:
-      source: '^\S+$'
+      source: '^\S*$'
       error: "Password must not contain spaces."
   query_scope:
     value: 'one'


### PR DESCRIPTION
Currently, the password field cannot be empty, though the username field can be. I believe this is a bug.
