### PR TITLE
Allow blank passwords for LDAP binds

### DIFF
--- a/environment_config.yaml
+++ b/environment_config.yaml
@@ -60,7 +60,7 @@ attributes:
     weight: 35
     type: "password"
     regex:
-      source: '^\S+$'
+      source: '^\S+$|^$'
       error: "Password must not contain spaces."
   query_scope:
     value: 'one'


### PR DESCRIPTION
This will remove the requirement of having an LDAP bindDN username and password for LDAP queries.
